### PR TITLE
[Linux] BlueZ resistance to restart and loss of the adapter

### DIFF
--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -302,6 +302,13 @@ void BLEManagerImpl::HandlePlatformSpecificBLEEvent(const ChipDeviceEvent * apEv
         mFlags.Set(Flags::kAppRegistered);
         controlOpComplete = true;
         break;
+    case DeviceEventType::kPlatformLinuxBLEPeripheralSetupComplete:
+        ChipLogDetail(DeviceLayer, "kPlatformLinuxBLEPeripheralSetupComplete");
+        VerifyOrExit(apEvent->Platform.BLEPeripheralSetupComplete.mIsSuccess, err = CHIP_ERROR_INCORRECT_STATE);
+        mFlags.Clear(Flags::kAppRegistered).Clear(Flags::kAdvertisingConfigured).Clear(Flags::kAdvertising);
+
+        DriveBLEState();
+        break;
     default:
         break;
     }
@@ -725,6 +732,15 @@ void BLEManagerImpl::NotifyBLEPeripheralRegisterAppComplete(bool aIsSuccess, voi
     event.Type                                                 = DeviceEventType::kPlatformLinuxBLEPeripheralRegisterAppComplete;
     event.Platform.BLEPeripheralRegisterAppComplete.mIsSuccess = aIsSuccess;
     event.Platform.BLEPeripheralRegisterAppComplete.mpAppstate = apAppstate;
+    PlatformMgr().PostEventOrDie(&event);
+}
+
+void BLEManagerImpl::NotifyBLEPeripheralSetupComplete(bool aIsSuccess, void * apAppstate)
+{
+    ChipDeviceEvent event;
+    event.Type                                           = DeviceEventType::kPlatformLinuxBLEPeripheralSetupComplete;
+    event.Platform.BLEPeripheralSetupComplete.mIsSuccess = aIsSuccess;
+    event.Platform.BLEPeripheralSetupComplete.mpAppstate = apAppstate;
     PlatformMgr().PostEventOrDie(&event);
 }
 

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -93,6 +93,8 @@ public:
     static void HandleTXComplete(BLE_CONNECTION_OBJECT user_data);
 
     static void NotifyBLEPeripheralRegisterAppComplete(bool aIsSuccess, void * apAppstate);
+    static void NotifyBLEPeripheralSetupComplete(bool aIsSuccess, void * apAppstate);
+    static void NotifyBLEPeripheralAdvConfiguredComplete(bool aIsSuccess, void * apAppstate);
     static void NotifyBLEPeripheralAdvStartComplete(bool aIsSuccess, void * apAppstate);
     static void NotifyBLEPeripheralAdvStopComplete(bool aIsSuccess, void * apAppstate);
 

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -92,7 +92,10 @@ public:
     static void HandleTXCharCCCDWrite(BLE_CONNECTION_OBJECT user_data);
     static void HandleTXComplete(BLE_CONNECTION_OBJECT user_data);
 
+    static void NotifyBLEBluezLEAdvertisement1Release(bool aIsRunning);
     static void NotifyBLEBluezServiceRestarted(bool aIsRunning);
+    static void NotifyBLEBluezSetupAdapterComplete(bool aIsRunning);
+
     static void NotifyBLEPeripheralRegisterAppComplete(bool aIsSuccess, void * apAppstate);
     static void NotifyBLEPeripheralSetupComplete(bool aIsSuccess, void * apAppstate);
     static void NotifyBLEPeripheralAdvConfiguredComplete(bool aIsSuccess, void * apAppstate);
@@ -168,6 +171,7 @@ private:
         kUseCustomDeviceName      = 0x0100, /**< The application has configured a custom BLE device name. */
         kAdvertisingRefreshNeeded = 0x0200, /**< The advertising configuration/state in BLE layer needs to be updated. */
         kBluezServiceRestarted    = 0x0400, /**< The Bluez service has been restarted. */
+        kBluezAdapterReady        = 0x0800, /**< The Bluez adapter is setup and ready to use */
     };
 
     enum

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -92,6 +92,7 @@ public:
     static void HandleTXCharCCCDWrite(BLE_CONNECTION_OBJECT user_data);
     static void HandleTXComplete(BLE_CONNECTION_OBJECT user_data);
 
+    static void NotifyBLEBluezServiceRestarted(bool aIsRunning);
     static void NotifyBLEPeripheralRegisterAppComplete(bool aIsSuccess, void * apAppstate);
     static void NotifyBLEPeripheralSetupComplete(bool aIsSuccess, void * apAppstate);
     static void NotifyBLEPeripheralAdvConfiguredComplete(bool aIsSuccess, void * apAppstate);
@@ -166,6 +167,7 @@ private:
         kFastAdvertisingEnabled   = 0x0080, /**< The application has enabled fast advertising. */
         kUseCustomDeviceName      = 0x0100, /**< The application has configured a custom BLE device name. */
         kAdvertisingRefreshNeeded = 0x0200, /**< The advertising configuration/state in BLE layer needs to be updated. */
+        kBluezServiceRestarted    = 0x0400, /**< The Bluez service has been restarted. */
     };
 
     enum

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -92,9 +92,10 @@ public:
     static void HandleTXCharCCCDWrite(BLE_CONNECTION_OBJECT user_data);
     static void HandleTXComplete(BLE_CONNECTION_OBJECT user_data);
 
-    static void NotifyBLEBluezLEAdvertisement1Release(bool aIsRunning);
-    static void NotifyBLEBluezServiceRestarted(bool aIsRunning);
-    static void NotifyBLEBluezSetupAdapterComplete(bool aIsRunning);
+    static void NotifyBLEAdvertisementRelease(bool aIsRunning);
+    static void NotifyBLEAdapterConnected(bool aIsRunning);
+    static void NotifyBLEAdapterDisconnected(bool aIsRunning);
+    static void NotifyBLESetupAdapterComplete(bool aIsRunning);
 
     static void NotifyBLEPeripheralRegisterAppComplete(bool aIsSuccess, void * apAppstate);
     static void NotifyBLEPeripheralSetupComplete(bool aIsSuccess, void * apAppstate);
@@ -170,8 +171,8 @@ private:
         kFastAdvertisingEnabled   = 0x0080, /**< The application has enabled fast advertising. */
         kUseCustomDeviceName      = 0x0100, /**< The application has configured a custom BLE device name. */
         kAdvertisingRefreshNeeded = 0x0200, /**< The advertising configuration/state in BLE layer needs to be updated. */
-        kBluezServiceRestarted    = 0x0400, /**< The Bluez service has been restarted. */
-        kBluezAdapterReady        = 0x0800, /**< The Bluez adapter is setup and ready to use */
+        kAdapterAvailable         = 0x0400, /**< The Bluez service has been restarted. */
+        kAdapterReady             = 0x0800, /**< The Bluez adapter is setup and ready to use */
     };
 
     enum

--- a/src/platform/Linux/CHIPDevicePlatformEvent.h
+++ b/src/platform/Linux/CHIPDevicePlatformEvent.h
@@ -45,6 +45,7 @@ enum PublicPlatformSpecificEventTypes
 enum InternalPlatformSpecificEventTypes
 {
     kPlatformLinuxEvent = kRange_InternalPlatformSpecific,
+    kPlatformLinuxBLEBluezServiceRestarted,
     kPlatformLinuxBLECentralConnected,
     kPlatformLinuxBLECentralConnectFailed,
     kPlatformLinuxBLEWriteComplete,
@@ -67,6 +68,10 @@ struct ChipDevicePlatformEvent
 {
     union
     {
+        struct
+        {
+            bool mIsRunning;
+        } BLEBluezServiceRestarted;
         struct
         {
             BLE_CONNECTION_OBJECT mConnection;

--- a/src/platform/Linux/CHIPDevicePlatformEvent.h
+++ b/src/platform/Linux/CHIPDevicePlatformEvent.h
@@ -54,7 +54,8 @@ enum InternalPlatformSpecificEventTypes
     kPlatformLinuxBLEOutOfBuffersEvent,
     kPlatformLinuxBLEPeripheralRegisterAppComplete,
     kPlatformLinuxBLEPeripheralAdvStartComplete,
-    kPlatformLinuxBLEPeripheralAdvStopComplete
+    kPlatformLinuxBLEPeripheralAdvStopComplete,
+    kPlatformLinuxBLEPeripheralSetupComplete
 };
 
 } // namespace DeviceEventType
@@ -93,6 +94,11 @@ struct ChipDevicePlatformEvent
             bool mIsSuccess;
             void * mpAppstate;
         } BLEPeripheralRegisterAppComplete;
+        struct
+        {
+            bool mIsSuccess;
+            void * mpAppstate;
+        } BLEPeripheralSetupComplete;
         struct
         {
             bool mIsSuccess;

--- a/src/platform/Linux/CHIPDevicePlatformEvent.h
+++ b/src/platform/Linux/CHIPDevicePlatformEvent.h
@@ -45,9 +45,10 @@ enum PublicPlatformSpecificEventTypes
 enum InternalPlatformSpecificEventTypes
 {
     kPlatformLinuxEvent = kRange_InternalPlatformSpecific,
-    kPlatformLinuxBLEBluezLEAdvertisement1Release,
-    kPlatformLinuxBLEBluezServiceRestarted,
-    kPlatformLinuxBLEBluezSetupAdapterComplete,
+    kPlatformLinuxBLEAdvertisementRelease,
+    kPlatformLinuxBLEAdapterDisconnected,
+    kPlatformLinuxBLEAdapterConnected,
+    kPlatformLinuxBLESetupAdapterComplete,
     kPlatformLinuxBLECentralConnected,
     kPlatformLinuxBLECentralConnectFailed,
     kPlatformLinuxBLEWriteComplete,
@@ -71,16 +72,20 @@ struct ChipDevicePlatformEvent
     {
         struct
         {
-            bool mIsBluezRunning;
-        } BLEBluezLEAdvertisement1Release;
+            bool mIsBLERunning;
+        } BLEAdvertisementRelease;
         struct
         {
-            bool mIsBluezRunning;
-        } BLEBluezServiceRestarted;
+            bool mIsBLERunning;
+        } BLEAdapterConnected;
         struct
         {
-            bool mIsBluezRunning;
-        } BLEBluezSetupAdapter;
+            bool mIsBLERunning;
+        } BLEAdapterDisconnected;
+        struct
+        {
+            bool mIsBLERunning;
+        } BLESetupAdapter;
         struct
         {
             BLE_CONNECTION_OBJECT mConnection;

--- a/src/platform/Linux/CHIPDevicePlatformEvent.h
+++ b/src/platform/Linux/CHIPDevicePlatformEvent.h
@@ -45,7 +45,9 @@ enum PublicPlatformSpecificEventTypes
 enum InternalPlatformSpecificEventTypes
 {
     kPlatformLinuxEvent = kRange_InternalPlatformSpecific,
+    kPlatformLinuxBLEBluezLEAdvertisement1Release,
     kPlatformLinuxBLEBluezServiceRestarted,
+    kPlatformLinuxBLEBluezSetupAdapterComplete,
     kPlatformLinuxBLECentralConnected,
     kPlatformLinuxBLECentralConnectFailed,
     kPlatformLinuxBLEWriteComplete,
@@ -55,8 +57,7 @@ enum InternalPlatformSpecificEventTypes
     kPlatformLinuxBLEOutOfBuffersEvent,
     kPlatformLinuxBLEPeripheralRegisterAppComplete,
     kPlatformLinuxBLEPeripheralAdvStartComplete,
-    kPlatformLinuxBLEPeripheralAdvStopComplete,
-    kPlatformLinuxBLEPeripheralSetupComplete
+    kPlatformLinuxBLEPeripheralAdvStopComplete
 };
 
 } // namespace DeviceEventType
@@ -70,8 +71,16 @@ struct ChipDevicePlatformEvent
     {
         struct
         {
-            bool mIsRunning;
+            bool mIsBluezRunning;
+        } BLEBluezLEAdvertisement1Release;
+        struct
+        {
+            bool mIsBluezRunning;
         } BLEBluezServiceRestarted;
+        struct
+        {
+            bool mIsBluezRunning;
+        } BLEBluezSetupAdapter;
         struct
         {
             BLE_CONNECTION_OBJECT mConnection;
@@ -99,11 +108,6 @@ struct ChipDevicePlatformEvent
             bool mIsSuccess;
             void * mpAppstate;
         } BLEPeripheralRegisterAppComplete;
-        struct
-        {
-            bool mIsSuccess;
-            void * mpAppstate;
-        } BLEPeripheralSetupComplete;
         struct
         {
             bool mIsSuccess;

--- a/src/platform/Linux/bluez/BluezAdvertisement.cpp
+++ b/src/platform/Linux/bluez/BluezAdvertisement.cpp
@@ -103,7 +103,7 @@ BluezLEAdvertisement1 * BluezAdvertisement::CreateLEAdvertisement()
     bluez_object_skeleton_set_leadvertisement1(object, adv);
     g_signal_connect(adv, "handle-release",
                      G_CALLBACK(+[](BluezLEAdvertisement1 * aAdv, GDBusMethodInvocation * aInv, BluezAdvertisement * self) {
-                         return self->BluezLEAdvertisement1Release(aAdv, aInv);
+                         BLEManagerImpl::NotifyBLEBluezLEAdvertisement1Release(self->mIsAdvertising);
                      }),
                      this);
 
@@ -113,14 +113,13 @@ BluezLEAdvertisement1 * BluezAdvertisement::CreateLEAdvertisement()
     return adv;
 }
 
-gboolean BluezAdvertisement::BluezLEAdvertisement1Release(BluezLEAdvertisement1 * aAdv, GDBusMethodInvocation * aInvocation)
+void BluezAdvertisement::BluezLEAdvertisement1Release()
 {
     ChipLogDetail(DeviceLayer, "Release BLE adv object in %s", __func__);
     g_dbus_object_manager_server_unexport(mpRoot, mpAdvPath);
     g_object_unref(mpAdv);
     mpAdv          = nullptr;
     mIsAdvertising = false;
-    return TRUE;
 }
 
 CHIP_ERROR BluezAdvertisement::InitImpl()

--- a/src/platform/Linux/bluez/BluezAdvertisement.cpp
+++ b/src/platform/Linux/bluez/BluezAdvertisement.cpp
@@ -103,7 +103,7 @@ BluezLEAdvertisement1 * BluezAdvertisement::CreateLEAdvertisement()
     bluez_object_skeleton_set_leadvertisement1(object, adv);
     g_signal_connect(adv, "handle-release",
                      G_CALLBACK(+[](BluezLEAdvertisement1 * aAdv, GDBusMethodInvocation * aInv, BluezAdvertisement * self) {
-                         BLEManagerImpl::NotifyBLEBluezLEAdvertisement1Release(self->mIsAdvertising);
+                         BLEManagerImpl::NotifyBLEAdvertisementRelease(self->mIsAdvertising);
                      }),
                      this);
 
@@ -113,7 +113,7 @@ BluezLEAdvertisement1 * BluezAdvertisement::CreateLEAdvertisement()
     return adv;
 }
 
-void BluezAdvertisement::BluezLEAdvertisement1Release()
+void BluezAdvertisement::LEAdvertisementRelease()
 {
     ChipLogDetail(DeviceLayer, "Release BLE adv object in %s", __func__);
     g_dbus_object_manager_server_unexport(mpRoot, mpAdvPath);

--- a/src/platform/Linux/bluez/BluezAdvertisement.h
+++ b/src/platform/Linux/bluez/BluezAdvertisement.h
@@ -60,7 +60,7 @@ public:
     ///
     /// BLE advertising is release by event call back. handle-release signal not emitted
     /// when bluetooth service was killed by kill -9
-    void BluezLEAdvertisement1Release();
+    void LEAdvertisementRelease();
 
 private:
     BluezLEAdvertisement1 * CreateLEAdvertisement();

--- a/src/platform/Linux/bluez/BluezAdvertisement.h
+++ b/src/platform/Linux/bluez/BluezAdvertisement.h
@@ -56,9 +56,14 @@ public:
     /// completion via a call to BLEManagerImpl::NotifyBLEPeripheralAdvStopComplete().
     CHIP_ERROR Stop();
 
+    /// Release BLE advertising
+    ///
+    /// BLE advertising is release by event call back. handle-release signal not emitted
+    /// when bluetooth service was killed by kill -9
+    void BluezLEAdvertisement1Release();
+
 private:
     BluezLEAdvertisement1 * CreateLEAdvertisement();
-    gboolean BluezLEAdvertisement1Release(BluezLEAdvertisement1 * aAdv, GDBusMethodInvocation * aInv);
 
     CHIP_ERROR InitImpl();
 
@@ -77,9 +82,8 @@ private:
     bool mIsAdvertising = false;
 
     Ble::ChipBLEDeviceIdentificationInfo mDeviceIdInfo;
-    char * mpAdvPath     = nullptr;
-    char * mpAdapterName = nullptr;
-    char * mpAdvUUID     = nullptr;
+    char * mpAdvPath = nullptr;
+    char * mpAdvUUID = nullptr;
     ChipAdvType mAdvType;
     uint16_t mAdvDurationMs = 0;
 };

--- a/src/platform/Linux/bluez/BluezAdvertisement.h
+++ b/src/platform/Linux/bluez/BluezAdvertisement.h
@@ -82,8 +82,9 @@ private:
     bool mIsAdvertising = false;
 
     Ble::ChipBLEDeviceIdentificationInfo mDeviceIdInfo;
-    char * mpAdvPath = nullptr;
-    char * mpAdvUUID = nullptr;
+    char * mpAdvPath     = nullptr;
+    char * mpAdapterName = nullptr;
+    char * mpAdvUUID     = nullptr;
     ChipAdvType mAdvType;
     uint16_t mAdvDurationMs = 0;
 };

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -112,6 +112,7 @@ private:
     gboolean BluezCharacteristicAcquireNotify(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv, GVariant * aOptions);
     gboolean BluezCharacteristicConfirm(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv);
 
+    void BluezSignalNameOwnerChanged(const char * aNameOwner);
     void BluezSignalOnObjectAdded(GDBusObjectManager * aManager, GDBusObject * aObject);
     void BluezSignalOnObjectRemoved(GDBusObjectManager * aManager, GDBusObject * aObject);
     void BluezSignalInterfacePropertiesChanged(GDBusObjectManagerClient * aManager, GDBusObjectProxy * aObject,
@@ -143,6 +144,7 @@ private:
     GDBusObjectManager * mpObjMgr = nullptr;
     BluezAdapter1 * mpAdapter     = nullptr;
     BluezDevice1 * mpDevice       = nullptr;
+    bool mIsBluezRunning          = false;
 
     // Objects (interfaces) published by this service
     GDBusObjectManagerServer * mpRoot = nullptr;

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -72,6 +72,7 @@ public:
     CHIP_ERROR Init(uint32_t aAdapterId, bool aIsCentral, const char * apBleAddr, const char * apBleName);
     void Shutdown();
 
+    void SetupAdapter();
     BluezAdapter1 * GetAdapter() const { return mpAdapter; }
     const char * GetAdapterName() const { return mpAdapterName; }
 
@@ -94,7 +95,6 @@ private:
 
     CHIP_ERROR StartupEndpointBindings();
 
-    void SetupAdapter();
     void SetupGattServer(GDBusConnection * aConn);
     void SetupGattService();
 

--- a/src/platform/Linux/bluez/Types.h
+++ b/src/platform/Linux/bluez/Types.h
@@ -55,6 +55,12 @@
 namespace chip {
 
 template <>
+struct GAutoPtrDeleter<BluezAdapter1>
+{
+    using deleter = GObjectDeleter;
+};
+
+template <>
 struct GAutoPtrDeleter<BluezDevice1>
 {
     using deleter = GObjectDeleter;


### PR DESCRIPTION
### Problem

Currently, there is no protection against restarting or losing the adapter in BlueZ. If the Bluetooth service is stopped and restarted, the application does not return to proper operation. Similarly, in the case of a kill on BlueZ.

### Changes

The change makes the BlueZ service if the service is restarted or killed, and if the adapter is plugged in after the application is launched, the application will start all necessary operations for BLE. Ejecting the device will remove the adapter, then reinserting it will re-register the adapter again in the application. 

### Testing

CI will test for potential build breaks.

Start the lighting-app and perform bluetooth service restart `service bluetooth restart` perform commissioning on this application. BLE should be ready for this again.

Launch the lighting-app and perform a restart of the bluetooth service `kill -9 bluetooth` performing commissioning on this application. BLE should be ready for this again.

Physical disconnection and connection of the BLE adapter