### PR TITLE
 [Linux] Fix of not disconnected bluez signal

### DIFF
--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -855,11 +855,7 @@ static void EndpointCleanup(BluezEndpoint * apEndpoint)
             g_object_unref(apEndpoint->mpConnectCancellable);
             apEndpoint->mpConnectCancellable = nullptr;
         }
-        if (apEndpoint->mpObjMgr != nullptr)
-        {
-            g_object_unref(apEndpoint->mpObjMgr);
-            apEndpoint->mpObjMgr = nullptr;
-        }
+
         g_free(apEndpoint);
     }
 }

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -77,8 +77,9 @@ struct BluezEndpoint
 
     // Objects (interfaces) subscibed to by this service
     GDBusObjectManager * mpObjMgr = nullptr;
-    BluezAdapter1 * mpAdapter     = nullptr;
-    BluezDevice1 * mpDevice       = nullptr;
+    gulong BluezSigHandlersID[3]; ///< Bluez signal handlers id for disconnect
+    BluezAdapter1 * mpAdapter = nullptr;
+    BluezDevice1 * mpDevice   = nullptr;
 
     // Objects (interfaces) published by this service
     GDBusObjectManagerServer * mpRoot;


### PR DESCRIPTION
### Problem

chip-tool in random situations after completing the scan and closing the application gets the signal "interface-proxy-properties-changed" and the application receives errors from glib. 

chip-tool log error:
```
[1698074064.280306][433940:433940] CHIP:DL: Inet Layer shutdown
[1698074064.280388][433940:433940] CHIP:DL: BLE shutdown
[1698074064.280292][433940:433946] CHIP:DL: aEndpoint.mpConnMap in UpdateConnectionTable
[1698074064.280855][433940:433940] CHIP:DL: System Layer shutdown
[1698074064.281220][433940:433946] CHIP:DL: FAIL: NULL aEndpoint.mpConnMap in UpdateConnectionTable <<(added log)

(process:433940): GLib-CRITICAL **: 17:14:24.281: g_hash_table_lookup: assertion 'hash_table != NULL' failed
```

### Changes

Adding bluez signal disconnection to the bluez shutdown function.

### Testing

CI will test for potential build breaks. 